### PR TITLE
Minor performance improvement in match_pairs_exporth5

### DIFF
--- a/immatch/utils/localize_sfm_helper.py
+++ b/immatch/utils/localize_sfm_helper.py
@@ -236,7 +236,7 @@ def match_pairs_with_keys_exporth5(matcher, pairs, pair_keys, match_file, debug=
         matched = list(fmatch.keys())
         print(f'\nLoad match file, existing matches {len(matched)}')
         print(f'Start matching, total {len(pairs)} pairs...')
-        for pair, key in tqdm(zip(pairs, pair_keys), smoothing=.1):
+        for pair, key in tqdm(zip(pairs, pair_keys), total=len(pairs), smoothing=.1):
             im1_path, im2_path = pair
             if key in matched:
                 num_matches.append(len(fmatch[key]['matches']))


### PR DESCRIPTION
I traded off a bit of memory for a substantial reduction in execution time. 
This loop took 1 minute before to complete for my aachen test case, now it takes 2 seconds.

Also added a minor change that allows tqdm to predict how much time the pairwise matching stage takes.