### PR TITLE
Added numpy import to patch2pix.py

### DIFF
--- a/immatch/modules/patch2pix.py
+++ b/immatch/modules/patch2pix.py
@@ -1,5 +1,6 @@
 from argparse import Namespace
 import torch
+import numpy as np
 from pathlib import Path
 import sys
 patch2pix_path = Path(__file__).parent / '../../third_party/patch2pix'


### PR DESCRIPTION
Added an import for numpy. Without the import, I am not able to run patch2pix with superglue features as I get an error that np is undefined.