### PR TITLE
Reproduce loftr hpatches (almost)

### DIFF
--- a/configs/loftr.yml
+++ b/configs/loftr.yml
@@ -9,4 +9,4 @@ example:
     imsize: -1
 hpatch:        
     <<: *default
-    imsize: 1024
+    imsize: 480

--- a/immatch/eval_hpatches.py
+++ b/immatch/eval_hpatches.py
@@ -81,7 +81,7 @@ def eval_hpatches(
 
 if __name__ == '__main__':    
     parser = argparse.ArgumentParser(description='Benchmark HPatches')
-    parser.add_argument('--gpu', '-gpu', type=str, default=0)
+    parser.add_argument('--gpu', '-gpu', type=str, default='0')
     parser.add_argument('--root_dir', type=str, default='.')  
     parser.add_argument('--odir', type=str, default='outputs/hpatches')
     parser.add_argument('--config', type=str,  nargs='*', default=None)    

--- a/immatch/modules/loftr.py
+++ b/immatch/modules/loftr.py
@@ -49,7 +49,7 @@ class LoFTR(Matching):
 
         upscale = np.array([sc1 + sc2])
         matches, kpts1, kpts2, scores = self.match_inputs_(gray1, gray2)
-        matches = upscale * matches
-        kpts1 = sc1 * kpts1
-        kpts2 = sc2 * kpts2
-        return matches, kpts1, kpts2, scores
+        matches = matches
+        kpts1 = kpts1
+        kpts2 = kpts2
+        return matches, kpts1, kpts2, scores, upscale.squeeze(0)

--- a/immatch/utils/data_io.py
+++ b/immatch/utils/data_io.py
@@ -10,10 +10,10 @@ def lprint(ms, log=None):
         log.write(ms+'\n')
         log.flush()
 
-def resize_im(wo, ho, imsize=None, dfactor=1):
+def resize_im(wo, ho, imsize=None, dfactor=1, value_to_scale=max):
     wt, ht = wo, ho
-    if imsize and max(wo, ho) > imsize and imsize > 0:
-        scale = imsize / max(wo, ho)
+    if imsize and value_to_scale(wo, ho) > imsize and imsize > 0:
+        scale = imsize / value_to_scale(wo, ho)
         ht, wt = int(round(ho * scale)), int(round(wo * scale))
 
     # Make sure new sizes are divisible by the given factor
@@ -42,9 +42,10 @@ def load_gray_scale_tensor(im_path, device, imsize=None, dfactor=1):
     return gray, scale
 
 def load_gray_scale_tensor_cv(im_path, device, imsize=None, dfactor=1):
+    # Used for LoFTR
     im = cv2.imread(im_path, cv2.IMREAD_GRAYSCALE)
     ho, wo = im.shape
-    wt, ht, scale = resize_im(wo, ho, imsize=imsize, dfactor=dfactor)
+    wt, ht, scale = resize_im(wo, ho, imsize=imsize, dfactor=dfactor, value_to_scale=min)
     im = cv2.resize(im, (wt, ht))
     im = transforms.functional.to_tensor(im).unsqueeze(0).to(device)
     return im, scale

--- a/immatch/utils/hpatches_helper.py
+++ b/immatch/utils/hpatches_helper.py
@@ -198,9 +198,9 @@ def eval_hpatches(
                     im = Image.open(im1_path)
                     w, h = im.size
                     corners = np.array([[0, 0, 1],
-                                        [0, w - 1, 1],
-                                        [h - 1, 0, 1],
-                                        [h - 1, w - 1, 1]])
+                                        [0, h - 1, 1],
+                                        [w - 1, 0, 1],
+                                        [w - 1, h - 1, 1]])
                     real_warped_corners = np.dot(corners, np.transpose(H_gt))
                     real_warped_corners = real_warped_corners[:, :2] / real_warped_corners[:, 2:]
                     warped_corners = np.dot(corners, np.transpose(H_pred))

--- a/immatch/utils/hpatches_helper.py
+++ b/immatch/utils/hpatches_helper.py
@@ -160,6 +160,12 @@ def eval_hpatches(
                 match_res = matcher(im1_path, im2_path)
                 match_time.append(time.time() - t0)
                 matches, p1s, p2s = match_res[0:3]
+                scale = match_res[4]
+                # Homographies from downscaled images to fullscale
+                H_scale_1 = scale_homography(scale[0], scale[1])
+                H_scale_2 = scale_homography(scale[2], scale[3])
+                # Groundtruth between downscaled images
+                H_gt = np.linalg.inv(H_scale_2) @ H_gt @ H_scale_1
             except:
                 p1s = p2s = matches = []
                 match_failed += 1
@@ -197,6 +203,7 @@ def eval_hpatches(
                 else:
                     im = Image.open(im1_path)
                     w, h = im.size
+                    w, h = w / scale[0], h / scale[1]
                     corners = np.array([[0, 0, 1],
                                         [0, h - 1, 1],
                                         [w - 1, 0, 1],
@@ -231,3 +238,8 @@ def eval_hpatches(
         lprint_('==== Homography Estimation ====')        
         lprint_(f'Hest solver={h_solver} est_failed={h_failed} ransac_thres={ransac_thres} inlier_rate={np.mean(inlier_ratio):.2f}')
         lprint_(eval_summary_homography(dists_sa, dists_si, dists_sv, thres))
+
+def scale_homography(sw, sh):
+    return np.array([[sw,  0, 0],
+                     [ 0, sh, 0],
+                     [ 0,  0, 1]])

--- a/immatch/utils/localize_sfm_helper.py
+++ b/immatch/utils/localize_sfm_helper.py
@@ -254,7 +254,7 @@ def match_pairs_with_keys_exporth5(matcher, pairs, pair_keys, match_file, debug=
                 continue
 
             matches = match_res[0]
-            scores = match_res[-1]
+            scores = match_res[3]
             N = len(matches)
             num_matches.append(N)
 


### PR DESCRIPTION
Running 
```
python -m immatch.eval_hpatches --config 'loftr' --task 'homography' --root_dir . --ransac_thres=3 --h_solver cv
```
yields
```
>>>>Eval hpatches: task=homography method=LoFTR_outdoor_ds rthres=3.0 thres=[1, 3, 5, 10] 
>>Finished, pairs=540 match_failed=0 matches=2599.4 match_time=0.12s
==== Homography Estimation ====
Hest solver=cv est_failed=0 ransac_thres=3.0 inlier_rate=0.86
Hest Correct: a=[0.64 0.87 0.92 0.95]
i=[0.81 0.98 0.99 1.  ]
v=[0.49 0.77 0.85 0.91]
Hest AUC: a=[0.36 0.65 0.75 0.84]
i=[0.48 0.79 0.87 0.93]
v=[0.25 0.52 0.64 0.76]
```
which should be compared to the values reported in the paper: `Hest AUC: a=[?, 65.9%, 75.6%, 84.6%]`.
There they only use the top 1k matches, which I haven't tried yet.

Most important changes:

- A crucial typo on the image corners ( h and w switched )
- Calculating pixel errors in the downsized images instead of in the original - this obviously reduces the errors.

I don't know if the changes I made break something non-LoFTR, non-HPatches related, but they probably do so you will want to rewrite some of the changes.