### PR TITLE
Further efforts to reproduce loftr hpatches

### DIFF
--- a/configs/loftr.yml
+++ b/configs/loftr.yml
@@ -3,6 +3,7 @@ default: &default
     ckpt: 'pretrained/loftr/outdoor_ds.ckpt'
     match_threshold: 0.2
     imsize: -1
+    aspect_ratio: -1
     no_match_upscale: False
 example:
     <<: *default
@@ -10,5 +11,6 @@ example:
     imsize: -1
 hpatch:        
     <<: *default
-    imsize: 480
+    imsize: 640
+    aspect_ratio: 1.333333  # images will be 640x480 or 480x640
     no_match_upscale: True

--- a/configs/loftr.yml
+++ b/configs/loftr.yml
@@ -3,7 +3,7 @@ default: &default
     ckpt: 'pretrained/loftr/outdoor_ds.ckpt'
     match_threshold: 0.2
     imsize: -1
-    no_matches_upscale: False
+    no_match_upscale: False
 example:
     <<: *default
     match_threshold: 0.5

--- a/configs/loftr.yml
+++ b/configs/loftr.yml
@@ -5,6 +5,7 @@ default: &default
     imsize: -1
     aspect_ratio: -1
     no_match_upscale: False
+    nbr_matches: -1
 example:
     <<: *default
     match_threshold: 0.5
@@ -15,3 +16,4 @@ hpatch:
     imsize: 640
     aspect_ratio: 1.333333  # images will be 640x480 or 480x640
     no_match_upscale: True
+    nbr_matches: 1000

--- a/configs/loftr.yml
+++ b/configs/loftr.yml
@@ -11,6 +11,7 @@ example:
     imsize: -1
 hpatch:        
     <<: *default
+    match_threshold: 0.5
     imsize: 640
     aspect_ratio: 1.333333  # images will be 640x480 or 480x640
     no_match_upscale: True

--- a/immatch/modules/loftr.py
+++ b/immatch/modules/loftr.py
@@ -17,6 +17,7 @@ class LoFTR(Matching):
         self.aspect_ratio = args.aspect_ratio
         self.match_threshold = args.match_threshold
         self.no_match_upscale = args.no_match_upscale
+        self.nbr_matches = args.nbr_matches
 
         # Load model
         conf = dict(default_cfg)
@@ -44,6 +45,12 @@ class LoFTR(Matching):
         kpts1 = batch['mkpts0_f'].cpu().numpy()
         kpts2 = batch['mkpts1_f'].cpu().numpy()
         scores = batch['mconf'].cpu().numpy()
+        if self.nbr_matches and self.nbr_matches > 0:
+            ids = np.argsort(scores)[-self.nbr_matches:]
+            kpts1 = kpts1[ids]
+            kpts2 = kpts2[ids]
+            scores = scores[ids]
+
         matches = np.concatenate([kpts1, kpts2], axis=1)
         return matches, kpts1, kpts2, scores
 

--- a/immatch/modules/loftr.py
+++ b/immatch/modules/loftr.py
@@ -14,6 +14,7 @@ class LoFTR(Matching):
             args = Namespace(**args)
 
         self.imsize = args.imsize        
+        self.aspect_ratio = args.aspect_ratio
         self.match_threshold = args.match_threshold
         self.no_match_upscale = args.no_match_upscale
 
@@ -34,7 +35,7 @@ class LoFTR(Matching):
         
     def load_im(self, im_path):
         return load_gray_scale_tensor_cv(
-            im_path, self.device, imsize=self.imsize, dfactor=8
+            im_path, self.device, imsize=self.imsize, aspect_ratio=self.aspect_ratio, dfactor=8
         )
 
     def match_inputs_(self, gray1, gray2):

--- a/immatch/utils/hpatches_helper.py
+++ b/immatch/utils/hpatches_helper.py
@@ -197,7 +197,7 @@ def eval_hpatches(
             if 'homography' in task:
                 try:
                     if 'cv' in h_solver:
-                        H_pred, inliers = cv2.findHomography(matches[:, :2], matches[:, 2:4], cv2.RANSAC, ransac_thres)
+                        H_pred, inliers = cv2.findHomography(matches[:, :2], matches[:, 2:4], cv2.RANSAC, ransac_thres, confidence=0.99999)
                     else:
                         H_pred, inliers = pydegensac.findHomography(matches[:, :2], matches[:, 2:4], ransac_thres)
                 except:


### PR DESCRIPTION
More changes related to #20 .

Running `python -m immatch.eval_hpatches --config 'loftr' --task 'both' --rot_dir . --ransac_thres=3 --h_solver cv` now yields
```
>>>>Eval hpatches: task=matching+homography method=LoFTR_outdoor_ds_noms scale_H=True rthres=3.0 thres=[1, 3, 5, 10] 
>>Finished, pairs=540 match_failed=0 matches=913.1 match_time=0.12s
==== Image Matching ====
#Features: mean=913 min=7 max=1000
#(Old)Matches: a=913, i=975, v=856
#Matches: a=913, i=975, v=856
MMA@[ 1  3  5 10] px:
a=[0.73 0.95 0.96 0.97]
i=[0.8  0.99 0.99 1.  ]
v=[0.66 0.91 0.94 0.95]

==== Homography Estimation ====
Hest solver=cv est_failed=0 ransac_thres=3.0 inlier_rate=0.93
Hest Correct: a=[0.65 0.88 0.92 0.95]
i=[0.82 0.98 0.99 1.  ]
v=[0.49 0.79 0.86 0.9 ]
Hest AUC: a=[0.4  0.67 0.76 0.85]
i=[0.56 0.81 0.88 0.94]
v=[0.25 0.53 0.65 0.77]
```

These numbers (at 3px) are actually higher than in the LoFTR paper. Take what you find useful from this pull request.